### PR TITLE
Ignore CancelledError results.

### DIFF
--- a/amazon_photos/_api.py
+++ b/amazon_photos/_api.py
@@ -968,7 +968,7 @@ class AmazonPhotos:
             for task in tasks:
                 task.cancel()
             results = await asyncio.gather(*tasks, return_exceptions=True)
-            return [y for x in results if x for y in x]
+            return [y for x in results if isinstance(x, list) for y in x]
 
         folders = asyncio.run(main([{'id': self.root['id']}]))
         return folders


### PR DESCRIPTION
Initialization fails with:

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.12/site-packages/amazon_photos/_api.py", line 78, in __init__
    self.folders = self.get_folders()
                   ^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/amazon_photos/_api.py", line 973, in get_folders
    folders = asyncio.run(main([{'id': self.root['id']}]))
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/asyncio/runners.py", line 194, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "uvloop/loop.pyx", line 1517, in uvloop.loop.Loop.run_until_complete
  File "/usr/local/lib/python3.12/site-packages/amazon_photos/_api.py", line 971, in main
    return [y for x in results if x for y in x]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: 'CancelledError' object is not iterable
```