### PR TITLE
fix: filter BaseException in get_folders to handle CancelledError in Python 3.8+

### DIFF
--- a/amazon_photos/_api.py
+++ b/amazon_photos/_api.py
@@ -968,7 +968,7 @@ class AmazonPhotos:
             for task in tasks:
                 task.cancel()
             results = await asyncio.gather(*tasks, return_exceptions=True)
-            return [y for x in results if x for y in x]
+            return [y for x in results if x and not isinstance(x, BaseException) for y in x]
 
         folders = asyncio.run(main([{'id': self.root['id']}]))
         return folders


### PR DESCRIPTION
Bug: get_folders() raises TypeError: 'CancelledError' object is not iterable

In Python 3.8+, CancelledError was moved to inherit from BaseException instead of Exception. The list comprehension in get_folders() uses if x to filter results from asyncio.gather(return_exceptions=True), but this doesn't filter out CancelledError objects, causing a TypeError when iterating.

Symptoms:
```TypeError: 'CancelledError' object is not iterable```

Fix:
```
python
# Before
return [y for x in results if x for y in x]

# After  
return [y for x in results if x and not isinstance(x, BaseException) for y in x]
```
